### PR TITLE
Removed Prefix from MDC key/values, allow override of others, fixed timestamp, increase short message to 255

### DIFF
--- a/log4php/layouts/LoggerLayoutGelf.php
+++ b/log4php/layouts/LoggerLayoutGelf.php
@@ -67,7 +67,7 @@ class LoggerLayoutGelf extends LoggerLayout
         LoggerLevel::FATAL => self::CRITICAL,
     );
 
-    protected $_shortMessageLength = 70;
+    protected $_shortMessageLength = 255;
     protected $_hostname;
     protected $_shortMessageEndTag = self::SHORT_MESSAGE_END_TAG;
 
@@ -81,19 +81,25 @@ class LoggerLayoutGelf extends LoggerLayout
     {
         $messageAsArray = array(
             'version' => self::GELF_PROTOCOL_VERSION,
-            'timestamp' => $event->getTimeStamp(),
             'short_message' => $this->getShortMessage($event),
             'full_message' => $this->getFullMessage($event),
-            'facility' => $event->getLoggerName(),
-            'host' => $this->getHostname(),
             'level' => $this->getGELFLevel($event->getLevel()),
             'file' => $event->getLocationInformation()->getFileName(),
-            'line' => $event->getLocationInformation()->getLineNumber()
+            'line' => $event->getLocationInformation()->getLineNumber(),
+            'host' => $this->getHostname(),
+            'facility' => 'php',
+            '_logger' => $event->getLoggerName(),
+            '_timestamp' => $event->getTimeStamp(),
         );
 
         foreach ($event->getMDCMap() as $key => $value)
         {
-            $messageAsArray['_MDC_'.$key] = $value;
+            if ($key == 'file' || $key == 'line' || $key == 'facility') {
+                $messageAsArray[$key] = $value;
+            } else {
+                $messageAsArray['_' . $key] = $value;
+            }
+
         }
 
         return json_encode($messageAsArray);


### PR DESCRIPTION
-Allows for file / line to be overridden enabling custom php error handling scripts to log the original file/line of the
actual error.
-Fixes timestamp not being logged correctly
-Logs the logger name separate from the facility
-Allows facility name to be overridden
-Increases "Short Message" to 255
